### PR TITLE
Migrate smtpd to aiosmtpd

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ MAILSLURP_SENDER_EMAIL_ID=
 MAILSLURP_RECIEVER_EMAIL_ID=
 ```
 
-The [MailSlurp](https://www.mailslurp.com/) variables are optional. The system automatically sends test emails to the local DebuggingServer.
+The [MailSlurp](https://www.mailslurp.com/) variables are optional. The system automatically sends test emails to the local aiosmtpd server.
 
 If you wish to use MailSlurp, set the variables and modify `main.py`. 
 
@@ -198,17 +198,17 @@ However, it doesn't really matter.
 
 **Note:** Free MailSlurp users can only keep their Inbox IDs for a short duration, so you'll have to update the ID a lot.
 
-### Run smtpd DebuggingServer
+### Run aiosmtpd mail server
 In a separate terminal or command-line prompt, run:
 
 **Linux:**
 ```cmd
-python3 -m smtpd -c DebuggingServer -n localhost:1025
+python3 -m aiosmtpd -n -l localhost:1025
 ```
 
 **Windows:**
 ```cmd
-python -m smtpd -c DebuggingServer -n localhost:1025
+python -m aiosmtpd -n -l localhost:1025
 ```
 
 **Note:** Don't close out of the window. You will see the emails being sent here.

--- a/cmdline_driver.py
+++ b/cmdline_driver.py
@@ -3,11 +3,7 @@
 
 Test driver to check some stuff using the command line
 
-call venv/Scripts/activate.bat
-python cmdline_driver.py
-deactivate
-
-python -m smtpd -c DebuggingServer -n localhost:1025
+python -m aiosmtpd -n -l localhost:1025
 
 """
 

--- a/python_scripts/email_service.py
+++ b/python_scripts/email_service.py
@@ -3,12 +3,12 @@
 Basic python script to send emails
 
 Google doesn't allow for us to use an account to send mails insecurely,
-so we'll use mailslurp.com to generate test email accounts to send and receive
+so we'll use MailSlurp.com to generate test email accounts to send and receive
 messages.
 
-Also included is a localhost DebuggingServer
+Also included is a localhost aiosmtpd server
 
-Mailslurp has a limit to how many emails can be sent and received so use it sparingly.
+MailSlurp has a limit to how many emails can be sent and received so use it sparingly.
 
 USAGE:
 
@@ -76,7 +76,7 @@ def __mailslurp_send_email(subject_string: str, message_string: str):
 
 
 # Requires you to use commandline to open the port
-# python -m smtpd -c DebuggingServer -n localhost:1025
+# python -m aiosmtpd -n -l localhost:1025
 def __localhost_send_email(sender_email: str, recipient_email: str, email_subject: str, email_body: str):
     sender = sender_email
     receivers = recipient_email
@@ -90,10 +90,10 @@ def __localhost_send_email(sender_email: str, recipient_email: str, email_subjec
     try:
         with smtplib.SMTP("localhost", port) as server:
             server.sendmail(sender, receivers, msg.as_string())
-            print("Successfully sent email using the local DebugginServer")
+            print("Successfully sent email using the local aiosmtpd server")
     except Exception as e:
         print(e)
-        print("Error: Cant send email\nIf using localhost run:\npython -m smtpd -c DebuggingServer -n localhost:1025")
+        print("Error: Cant send email\nIf using localhost run:\npython -m aiosmtpd -n -l localhost:1025")
 
 
 def send_email(msg_type: int, account_name: str, using_mailslurp=False):
@@ -119,5 +119,5 @@ def send_email(msg_type: int, account_name: str, using_mailslurp=False):
         # Use sparingly
         __mailslurp_send_email(email_title, message)
     else:
-        # sender_email, recipient_email are made up because they don't really exist beyond the DebuggingServer
+        # sender_email, recipient_email are made up because they don't really exist beyond the local aiosmtpd server
         __localhost_send_email("no-reply@example.com", "admin@example.com", email_title, message)

--- a/python_scripts/main.py
+++ b/python_scripts/main.py
@@ -9,8 +9,8 @@ The system will lock out a user account if they fail three times to type their p
 Before the first run of the code.
 1) Set up the MySQL database using the initialize_database.sql
 2) Set up the .env file
-3) Make sure the mailslurp credentials are up-to-date
-    OR have smtpd running by using: python -m smtpd -c DebuggingServer -n localhost:1025
+3) Make sure the MailSlurp credentials are up-to-date
+    OR have aiosmtpd running by using: python -m aiosmtpd -n -l localhost:1025
 
 """
 import os

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ colorama==0.4.6 # https://pypi.org/project/colorama/ - This allows for colorful 
 
 mailslurp-client==15.16.22 # https://www.mailslurp.com/ - This is for sending test emails in email_service
 
+aiosmtpd # Local mail server for testing
 mysql-connector-python==8.0.32 # MySQL Database connector
 
 nltk==3.8.1 # This is for language processing in password_analysis

--- a/tests/local_test_mail_service.py
+++ b/tests/local_test_mail_service.py
@@ -1,22 +1,22 @@
 """
-This test can't easily be integrated into pytest because it requires DebuggingServer to run.
+This test can't easily be integrated into pytest because it requires the local aiosmtpd server to run.
 
-python -m smtpd -c DebuggingServer -n localhost:1025
+python -m aiosmtpd -n -l localhost:1025
 
-Also, if you want to test with mailslurp, you have to reset the accounts for fresh credentials.
+Also, if you want to test with MailSlurp, you have to reset the accounts for fresh credentials.
 
 """
 from python_scripts.email_service import send_email
 
 print("--- Starting LocalTest of email_service.py ---")
-print("Using DebuggingServer: ")
+print("Using Local Dev Server: ")
 # Send message that testUser has locked their account out after failing 3 times.
 send_email(1, "testUser", using_mailslurp=False)
 
 # Send message that someone has used hackedUser's decoy password.
 send_email(2, "hackedUser", using_mailslurp=False)
 
-print("Using Mailslurp: ")
-# Same messages but this time using Mailslurp <https://app.mailslurp.com/inboxes/>
+print("Using MailSlurp: ")
+# Same messages but this time using MailSlurp <https://app.mailslurp.com/inboxes/>
 send_email(1, "testUser", using_mailslurp=True)
 send_email(2, "hackedUser", using_mailslurp=True)


### PR DESCRIPTION
- The smtpd command to get the local mail will be deprecated in python 3.12. It already throws a few warning messages about it.
- Replace it with aiosmtpd